### PR TITLE
Fix "malformed package" error when using watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "frida-compile agent/index.ts -o _agent.js -c",
-    "watch": "frida-compile agent/index.ts -o _agent.js -w"
+    "watch": "frida-compile agent/index.ts -o _agent.js -w -c"
   },
   "devDependencies": {
     "@types/frida-gum": "^18.1.0",


### PR DESCRIPTION
Hi there,

In the latest version of this repo, using "npm run watch" fails to generate a proper Gum package with error "malformed package" during injection. I narrowed this down to the fact that the watch command was not using "-c" which enables compression. This PR adds that flag to the script.

Best,

Gbps 