### PR TITLE
Remove --no-pause argument from example command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 $ git clone git://github.com/oleavr/frida-agent-example.git
 $ cd frida-agent-example/
 $ npm install
-$ frida -U -f com.example.android --no-pause -l _agent.js
+$ frida -U -f com.example.android -l _agent.js
 ```
 
 ### Development workflow


### PR DESCRIPTION
Fixes #33

Update `README.md` to remove the `--no-pause` argument from the example command.